### PR TITLE
fix multiGPU

### DIFF
--- a/dialdoc/models/rag/retrieval_rag_dialdoc.py
+++ b/dialdoc/models/rag/retrieval_rag_dialdoc.py
@@ -453,11 +453,11 @@ class DialDocRagRetriever(RagRetriever):
         ids_batched = []
         vectors_batched = []
         scores_batched = []
-        for comb_h_s, curr_h_s, hist_h_s, dom_batch in zip(
+        for comb_h_s, curr_h_s, hist_h_s in zip(
             combined_hidden_states_batched,
             current_hidden_states_batched,
             history_hidden_states_batched,
-            domain_batched,
+            # domain_batched,
         ):
             start_time = time.time()
             if self.config.scoring_func in ["linear", "linear2", "linear3", "nonlinear"]:


### PR DESCRIPTION
Here may include a issue when multiGPUs are used. 
Since the default self.batch_size=8 at L452, when multiGPUs are used and data shape is more than 8, I found the `domain_batched` at line452  has actually fewer dimensions than it should be, which leads to the zip error at line 460. (suppose for 3 GPU with train batch size=4, with all domains, line 452 only returns one element, while the other three at line 456 returns 2 elements: one with shape (8,), the other with shape (4,) ) It is noticed that domain_batched is not  used afterward. So may be a straightforward way is to delete it.